### PR TITLE
Feature/#62 enemy standup

### DIFF
--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -5,6 +5,7 @@ import {
   enterTownHandler,
   enterDungeonHandler,
   loginHandler,
+  registerHandler,
   unlockCharacterHandler,
   townSelectHandler,
   connectHandler,
@@ -62,6 +63,10 @@ const handlers = {
   [HANDLER_IDS.C_CONNECT]: {
     handler: connectHandler,
     protoType: 'town.C_Connect',
+  },
+  [HANDLER_IDS.C_REGISTER]: {
+    handler: registerHandler,
+    protoType: 'town.C_Register',
   },
 
   // 다른 핸들러들을 추가

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -9,7 +9,6 @@ import {
   unlockCharacterHandler,
   townSelectHandler,
   connectHandler,
-  registerHandler,
 } from './game/town/enterHandler.js';
 import { avatarMoveHandler, avatarAnimationHandler } from './game/town/avatarHandler.js';
 import { characterUpgradeHandler, finalBossHandler } from './game/town/towerHandler.js';


### PR DESCRIPTION
적이 사망한 후 이벤트 처리
- 적이 사망한 후 플레이어가 사망했을 시 일어나는 현상 수정
- 플레이어를 마지막으로 공격한(사망시킨) 적이 승리모션(세러모니?)를 실행하도록 변경

resolve: #62 